### PR TITLE
Update battery voltage calculation to include diode drop

### DIFF
--- a/mazerunner-core/battery.h
+++ b/mazerunner-core/battery.h
@@ -37,7 +37,7 @@ class Battery {
 
   void update() {
     m_adc_value = adc.get_dark(m_adc_channel);
-    m_battery_volts = BATTERY_MULTIPLIER * m_adc_value;
+    m_battery_volts = (BATTERY_MULTIPLIER * m_adc_value) + BATTERY_DIODE_DROP;
   }
 
   float voltage() {

--- a/mazerunner-core/config-robot-orion.h
+++ b/mazerunner-core/config-robot-orion.h
@@ -387,8 +387,9 @@ const TurnParameters turn_params[4] = {
 // battery voltage calulation is done as efficiently as possible.
 // The compiler will do all these calculations so your program does not have to.
 
-const float BATTERY_R1 = 10000.0;  // resistor to battery +
-const float BATTERY_R2 = 10000.0;  // resistor to Gnd
+const float BATTERY_R1 = 10000.0;      // resistor to battery +
+const float BATTERY_R2 = 10000.0;      // resistor to Gnd
+const float BATTERY_DIODE_DROP = 0.9;  // Voltage drop as battery flows through a diode (D1)
 const float BATTERY_DIVIDER_RATIO = BATTERY_R2 / (BATTERY_R1 + BATTERY_R2);
 const float ADC_FSR = 1023.0;     // The maximum reading for the ADC
 const float ADC_REF_VOLTS = 5.0;  // Reference voltage of ADC

--- a/mazerunner-core/config-robot-osmium.h
+++ b/mazerunner-core/config-robot-osmium.h
@@ -343,8 +343,9 @@ const TurnParameters turn_params[4] = {
 // battery voltage calulation is done as efficiently as possible.
 // The compiler will do all these calculations so your program does not have to.
 
-const float BATTERY_R1 = 10000.0;  // resistor to battery +
-const float BATTERY_R2 = 10000.0;  // resistor to Gnd
+const float BATTERY_R1 = 10000.0;      // resistor to battery +
+const float BATTERY_R2 = 10000.0;      // resistor to Gnd
+const float BATTERY_DIODE_DROP = 0.9;  // Voltage drop as battery flows through a diode (D1)
 const float BATTERY_DIVIDER_RATIO = BATTERY_R2 / (BATTERY_R1 + BATTERY_R2);
 const float ADC_FSR = 1023.0;     // The maximum reading for the ADC
 const float ADC_REF_VOLTS = 5.0;  // Reference voltage of ADC


### PR DESCRIPTION
Diode D1 in the standard UKMARS Mazebot protects the system from reverse battery connection.  This diode has a forward voltage drop of around 0.9V.  This fix includes this voltage drop in the battery voltage calculation to more accurately reflect the actual battery voltage.