### PR TITLE
backspace management in cli.h

### DIFF
--- a/mazerunner-core/cli.h
+++ b/mazerunner-core/cli.h
@@ -172,8 +172,8 @@ class CommandLineInterface {
         return true;
       } else if (c == BACKSPACE) {
         if (m_index > 0) {
-          m_buffer[m_index] = 0;
           m_index--;
+          m_buffer[m_index] = 0;
           Serial.print(c);  // backspace only moves the cursor
           Serial.print(' ');
           Serial.print(c);


### PR DESCRIPTION
When the BS is the last character of the line, the last character is removed on the screen, but not removed in the buffer
Example:
  CMD 10<BS>
shows
  CMD 1
but in the buffer:
  CMD 10